### PR TITLE
fix: 解决因使用代理导致的B站视频无法下载问题

### DIFF
--- a/nonebot-plugin-resolver/core/bili23.py
+++ b/nonebot-plugin-resolver/core/bili23.py
@@ -17,7 +17,7 @@ async def download_b_file(url, full_file_name, progress_callback):
     :param progress_callback:
     :return:
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(local_address="0.0.0.0")) as client:
         async with client.stream("GET", url, headers=BILIBILI_HEADER) as resp:
             current_len = 0
             total_len = int(resp.headers.get('content-length', 0))


### PR DESCRIPTION
在Linux相同下，控制台使用代理后；解析B站视频偶尔会报错，日志如下
```
01-01 14:53:47 [ERROR] nonebot | Running Matcher(type='message', module=nonebot-plugin-resolver, lineno=58) failed.
Traceback (most recent call last):
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 67, in map_httpcore_exceptions
    yield
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 371, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
    raise exc from None
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
    response = await connection.handle_async_request(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_async/connection.py", line 101, in handle_async_request
    raise exc
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_async/connection.py", line 78, in handle_async_request
    stream = await self._connect(request)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_async/connection.py", line 124, in _connect
    stream = await self._network_backend.connect_tcp(**kwargs)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_backends/auto.py", line 31, in connect_tcp
    return await self._backend.connect_tcp(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 113, in connect_tcp
    with map_exceptions(exc_map):
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectTimeout

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/__init__.py", line 335, in run
    get_driver().run(*args, **kwargs)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/drivers/fastapi.py", line 186, in run
    uvicorn.run(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/uvicorn/main.py", line 579, in run
    server.run()
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/message.py", line 476, in check_and_run_matcher
    await _run_matcher(
> File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/message.py", line 428, in _run_matcher
    await matcher.run(bot, event, state, stack, dependency_cache)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/internal/matcher/matcher.py", line 850, in run
    await self.simple_run(bot, event, state, stack, dependency_cache)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/internal/matcher/matcher.py", line 825, in simple_run
    await handler(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot/dependencies/__init__.py", line 94, in __call__
    return await cast(Callable[..., Awaitable[R]], self.call)(**values)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot-plugin-resolver/__init__.py", line 109, in wrapper
    return await func(*args, **kwargs)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot-plugin-resolver/__init__.py", line 188, in wrapper
    return await func(*args, **kwargs)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot-plugin-resolver/__init__.py", line 335, in bilibili
    await asyncio.gather(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/nonebot-plugin-resolver/core/bili23.py", line 21, in download_b_file
    async with client.stream("GET", url, headers=BILIBILI_HEADER) as resp:
  File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1602, in stream
    response = await self.send(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1646, in send
    response = await self._send_handling_auth(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1674, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1711, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1748, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 370, in handle_async_request
    with map_httpcore_exceptions():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/ubuntu/resolver/.venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 84, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectTimeout
```

应用此行配置后不会再出现上述情况，推断原因应为[这个问题](https://github.com/python-telegram-bot/python-telegram-bot/discussions/4417?sort=old)，其他视频平台未测试，不知道是否有这个问题，